### PR TITLE
Adiciona valor à 'salt' para ser salvo no db

### DIFF
--- a/server/src/services/authentication.ts
+++ b/server/src/services/authentication.ts
@@ -66,6 +66,7 @@ export const signUp = async (user: User): Promise<User> => {
         nickname: user.nickname,
         email: user.nickname,
         role: 'DEFAULT_ROLE',
+        salt: salt,
         password: generatePassword(salt, user.password!),
     };
     await createUser(userCreated);


### PR DESCRIPTION
Atualmente, temos um bug na API que não permite que um usuário faça autenticação: não salvamos a coluna salt no banco e, consequentemente, não conseguimos fazer a validação de senha.