### PR TITLE
Implementa criação de posts para o fórum

### DIFF
--- a/client/src/CreatePost.js
+++ b/client/src/CreatePost.js
@@ -1,0 +1,162 @@
+import axios from "axios";
+import { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, Button, Grid, MenuItem, OutlinedInput, Select, TextField, Typography } from "@mui/material";
+import UserContext from "./UserContext";
+
+const CreatePost = () => {
+    const [title, setTitle] = useState('')
+    const [content, setContent] = useState('')
+    const [relatedArticle, setRelatedArticle] = useState('')
+
+    const navigate = useNavigate();
+
+    const userInfo = useContext(UserContext) ?? {username: 'mockUser'};
+
+    // funcao chamada ao clicar no botao "criar post"
+    const handleSubmit = (e) => {
+      e.preventDefault();
+
+      const post = {
+        content: content,
+        posterUsername: userInfo.username,
+        relatedArticle: relatedArticle,
+        title: title,
+      };
+
+      // ESPECIFICAR ENDPOINT DA REQUEST DE CRIAR POST
+      /*
+      try 
+      {
+        axios.post('api/endpointDeCriarPost', {post})
+      }
+
+      catch(error)
+      {
+        console.error(error)
+      }
+      */
+
+      window.alert("Seu post foi adicionado ao fórum! Obrigado.");
+
+      navigate('/forum');
+    }
+
+    return (
+        <Grid container sx={{ justifyContent: "left" }}>
+          <Grid sm={12} item sx={{ padding: 1, display: "flex", justifyContent: "center" }}>
+            <Box 
+              sx={{
+                display: 'flex',
+                flexDirection: "column",
+                bgcolor: "white",
+                width: 800,
+                maxHeight: 700,
+                borderRadius: 10,
+                boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.2)',
+                textAlign: 'left' 
+               }}
+            >
+              <Typography
+                sx={{
+                  mt: 4,
+                  ml: 4,
+                  fontSize: '24px',
+                  fontWeight: 'bold'
+                }}>Título do post:
+              </Typography>
+              <TextField
+                sx={{ 
+                  mb: 2,
+                  ml: 6,
+                  mt: 2,
+                  backgroundColor: "white" ,
+                  width: 700,
+                  '& input': {
+                    textAlign: 'left',
+                  }
+                }}
+                variant="outlined"
+                required
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                type="text"
+                placeholder="Digite um título para o post"
+              />
+              <Typography
+                sx={{
+                  mt: 4,
+                  ml: 4,
+                  fontSize: '24px',
+                  fontWeight: 'bold'
+                }}>Conteúdo do post:
+              </Typography>
+              <OutlinedInput multiline
+                rows={4}
+                sx={{ 
+                  mb: 2,
+                  ml: 6,
+                  mt: 2,
+                  backgroundColor: "white" ,
+                  width: 700,
+                  '& input': {
+                    textAlign: 'left',
+                  }
+                }}
+                required
+                placeholder="Digite o contéudo do post"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              />
+              <Typography
+                sx={{
+                  mt: 4,
+                  ml: 4,
+                  fontSize: '24px',
+                  fontWeight: 'bold'
+                }}>Artigo da Wiki relacionado:
+              </Typography>
+              <Select
+                sx={{ 
+                  mb: 2,
+                  ml: 6,
+                  mt: 2,
+                  backgroundColor: "white" ,
+                  width: 700,
+                }}
+                required
+                value={relatedArticle}
+                onChange={(e) => setRelatedArticle(e.target.value)}
+              >
+                <MenuItem value="MC102">MC102</MenuItem>
+                <MenuItem value="MC202">MC202</MenuItem>
+                <MenuItem value="MC322">MC322</MenuItem>
+              </Select>
+                <div style={{ flex: 1 }}></div>
+                <div
+                  sx ={{
+                    display: 'flex',
+                    justifyContent: 'space-between'
+                  }}
+                >
+                  <Button 
+                    variant="contained" 
+                    type="submit" 
+                    sx={{
+                       mt: 2,
+                       mr: 1,
+                       ml: 6,
+                       mb: 3
+                       }}
+                    onClick={handleSubmit}
+                  >
+                    Criar post
+                  </Button>
+                </div>
+            </Box>
+          </Grid>
+        </Grid>
+  );
+};
+
+export default CreatePost;

--- a/client/src/Menu.js
+++ b/client/src/Menu.js
@@ -7,6 +7,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import Forum from '@mui/icons-material/Forum';
+import HistoryEduIcon from '@mui/icons-material/HistoryEdu';
 import IconButton from '@mui/material/IconButton';
 import InboxIcon from '@mui/icons-material/MoveToInbox';
 import Key from '@mui/icons-material/Key';
@@ -18,6 +19,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import MailIcon from '@mui/icons-material/Mail';
 import MenuIcon from '@mui/icons-material/Menu';
+import RateReviewIcon from '@mui/icons-material/RateReview';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import UserContext from './UserContext';
@@ -30,11 +32,11 @@ import MC322 from './MC322';
 import Info from './Info';
 import axios from 'axios';
 import ForumHome from './ForumHome';
+import CreatePost from './CreatePost';
 import Home from './Home';
 import Login from './Login';
 import { Button } from '@mui/material';
 import { Navigate } from "react-router-dom";
-import CreatePost from './CreatePage';
 
 
 const drawerWidth = 240;
@@ -53,7 +55,11 @@ function ResponsiveDrawer(props) {
   const loginItems = [
     { title: "Login", route: "/login" },
     { title: "Cadastro", route: "/register" },
+  ]
+
+  const creationItems = [
     { title: "Criar página", route: "/create-page" },
+    { title: "Criar post", route: "/create-post" },
   ]
 
   const { window } = props;
@@ -119,6 +125,21 @@ function ResponsiveDrawer(props) {
               <ListItemButton>
                 <ListItemIcon>
                   {index % 2 === 0 ? <Key /> : <AssignmentInd />}
+                </ListItemIcon>
+                <ListItemText primary={item.title} />
+              </ListItemButton>
+            </ListItem>
+          </Link >
+        ))}
+      </List>
+      <Divider />
+      <List>
+        {creationItems.map((item, index) => (
+          <Link index={index} className='link-custom' to={item.route}>
+            <ListItem key={index}>
+              <ListItemButton>
+                <ListItemIcon>
+                  {index % 2 === 0 ? <HistoryEduIcon /> : <RateReviewIcon />}
                 </ListItemIcon>
                 <ListItemText primary={item.title} />
               </ListItemButton>
@@ -214,7 +235,7 @@ function ResponsiveDrawer(props) {
             <Route path="/home" element={<Home />} />
             <Route path="/forum" element={<ForumHome />} />
             <Route path="/register" element={<Register />} />
-            <Route path="/create-page" element={<CreatePost />} />
+            <Route path="/create-post" element={<CreatePost />} />
             <Route path="/login" element={<Login />} />
             <Route path="/MC102" element={<MC102 />} />
             <Route path="/MC202" element={<MC202 />} />


### PR DESCRIPTION
Esse PR realiza as seguintes ações:

- Cria o componente CreatePost;
- Implementa a route para o CreatePost no Menu;
- Separa as ações para criar post e criar artigo das demais ações no side menu.

Observações:

- A listagem de artigo relacionado durante a criação de um post ainda não é dinâmica -- por exemplo, se um novo artigo for criado, ele não aparecerá como opção;
- É necessário implementar no server e no DB o campo `relatedArticle` na tipagem dos posts. Isso será necessário também para a feature que relaciona artigo e post;
- É necessário adicionar no componente CreatePost o endpoint para a request de criar post.